### PR TITLE
Raise the required SDK version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Contains code to deal with internationalized/localized messages, date and number formatting and parsing, bi-directional text, and other internationalization issues.
 homepage: https://github.com/dart-lang/intl
 environment:
-  sdk: '>=1.4.0 <2.0.0'
+  sdk: '>=1.12.0 <2.0.0'
 documentation: http://www.dartdocs.org/documentation/intl/latest
 dependencies:
   analyzer: '>=0.13.2 <0.28.0'


### PR DESCRIPTION
Due to the introduction of null-aware operator in some code (see `NumberFormat.currencySymbol` property).